### PR TITLE
fix: typo in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
                     <p>The dimensions library defines types and functions for working with <em>sized
 containers</em>. A sized container contains its size as part of its type
 signature, much as one might encounter in dependently typed programming
-langauges.</p>
+languages.</p>
 
                 </div>
             </a>

--- a/gendocs.carp
+++ b/gendocs.carp
@@ -10,7 +10,7 @@
   "The dimensions library defines types and functions for working with *sized
   containers*. A sized container contains its size as part of its type
   signature, much as one might encounter in dependently typed programming
-  langauges.")
+  languages.")
 (Project.config "docs-generate-index" true)
 (Project.config "docs-logo" "dimensions-logo.svg")
 


### PR DESCRIPTION
This PR fixes a typo in docs (NB: typing `language` sucks!).

Cheers