### PR TITLE
fix: use new style docs to avoid unwanted code blocks

### DIFF
--- a/docs/Dimensional.html
+++ b/docs/Dimensional.html
@@ -72,14 +72,11 @@
                     (tabulate f)
                 </pre>
                 <p class="doc">
-                    <pre><code>Tabulate maps a `lookup` function (any function that takes an `Index` as an
-argument) over the positions of a sized functor.
-
-`(tabulate (lookup f))= (id f)`
-
-To make this function useful, one often needs to use an overarching context
-to ensure the resulting functor is sized appropriately. 
-</code></pre>
+                    <p>Tabulate maps a <code>lookup</code> function (any function that takes an <code>Index</code> as an
+argument) over the positions of a sized functor.</p>
+<p><code>(tabulate (lookup f))= (id f)</code></p>
+<p>To make this function useful, one often needs to use an overarching context
+to ensure the resulting functor is sized appropriately.</p>
 
                 </p>
             </div>
@@ -99,17 +96,12 @@ to ensure the resulting functor is sized appropriately.
                     (transpose f)
                 </pre>
                 <p class="doc">
-                    <pre><code>Transpose takes a sized functor whose inhabitants are sized functors and
-effectively swaps their sizes; it is equivalent to matrix transposition.
-
-For example, given a Vector of Size 3 of Vectors of Size 2
-
-`(Vector [(Vector [1 2]) (Vector [3 4]) (Vector [5 6])])`
-
-transpose will return a Vector of size 2 of Vectors of size 3:
-
-`(Vector [(Vector [1 3 5]) (Vector [2 4 6])])`
-</code></pre>
+                    <p>Transpose takes a sized functor whose inhabitants are sized functors and
+effectively swaps their sizes; it is equivalent to matrix transposition.</p>
+<p>For example, given a Vector of Size 3 of Vectors of Size 2</p>
+<p><code>(Vector [(Vector [1 2]) (Vector [3 4]) (Vector [5 6])])</code></p>
+<p>transpose will return a Vector of size 2 of Vectors of size 3:</p>
+<p><code>(Vector [(Vector [1 3 5]) (Vector [2 4 6])])</code></p>
 
                 </p>
             </div>

--- a/docs/Hompair.html
+++ b/docs/Hompair.html
@@ -115,12 +115,9 @@
                     (empty? pair)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns false. Hompairs may never be empty by definition.
-
-```
-(empty? &amp;(Hompair.of 1 1))
+                    <p>Returns false. Hompairs may never be empty by definition.</p>
+<pre><code>(empty? &amp;(Hompair.of 1 1))
 =&gt; false
-```
 </code></pre>
 
                 </p>
@@ -161,12 +158,9 @@
                     (len pair)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns the length of a Hompair.
-
-```
-(len (Hompair.of 1 1))
+                    <p>Returns the length of a Hompair.</p>
+<pre><code>(len (Hompair.of 1 1))
 =&gt; 2
-```
 </code></pre>
 
                 </p>
@@ -225,13 +219,10 @@
                     (nth pair index)
                 </pre>
                 <p class="doc">
-                    <pre><code>Retrieves the nth value from a Hompair using the int value of `index`. 
-If n is greater than or equal 1, returns the second member of the Hompair.
-
-```
-(nth &amp;(Hompair 1 2) (Index.init 0))
+                    <p>Retrieves the nth value from a Hompair using the int value of <code>index</code>.
+If n is greater than or equal 1, returns the second member of the Hompair.</p>
+<pre><code>(nth &amp;(Hompair 1 2) (Index.init 0))
 =&gt; 1
-```
 </code></pre>
 
                 </p>
@@ -252,12 +243,9 @@ If n is greater than or equal 1, returns the second member of the Hompair.
                     (of x y)
                 </pre>
                 <p class="doc">
-                    <pre><code>Constructs a new Hompair from values `x` and `y`.
-
-```
-(Hompair.of 2 4)
+                    <p>Constructs a new Hompair from values <code>x</code> and <code>y</code>.</p>
+<pre><code>(Hompair.of 2 4)
 =&gt; (Hompair 2 4)
-```
 </code></pre>
 
                 </p>
@@ -336,12 +324,9 @@ If n is greater than or equal 1, returns the second member of the Hompair.
                     (replicate x)
                 </pre>
                 <p class="doc">
-                    <pre><code>Creates a new Hompair with `x` as both of its members.
-
-```
-(Hompair.replicate 1)
+                    <p>Creates a new Hompair with <code>x</code> as both of its members.</p>
+<pre><code>(Hompair.replicate 1)
 =&gt; (Hompair 1 1)
-```
 </code></pre>
 
                 </p>
@@ -482,12 +467,9 @@ If n is greater than or equal 1, returns the second member of the Hompair.
                     (swap pair)
                 </pre>
                 <p class="doc">
-                    <pre><code>Swaps the position of each value in a Hompair.
-
-```
-(swap &amp;(Hompair.of 1 2))
+                    <p>Swaps the position of each value in a Hompair.</p>
+<pre><code>(swap &amp;(Hompair.of 1 2))
 =&gt; (Hompair 2 1)
-```
 </code></pre>
 
                 </p>
@@ -548,8 +530,7 @@ If n is greater than or equal 1, returns the second member of the Hompair.
                     (zero)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns a Hompair of the zero values of a given type.
-</code></pre>
+                    <p>Returns a Hompair of the zero values of a given type.</p>
 
                 </p>
             </div>

--- a/docs/Size.html
+++ b/docs/Size.html
@@ -215,11 +215,9 @@ are implemented in terms of <code>Size</code> and <code>Zero</code>.</p>
                     (size n)
                 </pre>
                 <p class="doc">
-                    <pre><code>Size types can be quite a pain to type out in full, as the rely on significant nesting.
-
-The size macro generates an appropriate Size based on an integer value, and
-may be used to generate a size type in functions signatures and macros.
-</code></pre>
+                    <p>Size types can be quite a pain to type out in full, as the rely on significant nesting.</p>
+<p>The size macro generates an appropriate Size based on an integer value, and
+may be used to generate a size type in functions signatures and macros.</p>
 
                 </p>
             </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -252,9 +252,8 @@ and supports generic programming.</p>
                     (map f v)
                 </pre>
                 <p class="doc">
-                    <pre><code> Maps a function `f` over all the elements of a Vector and returns a new
- Vector containing the results.
-</code></pre>
+                    <p>Maps a function <code>f</code> over all the elements of a Vector and returns a new
+Vector containing the results.</p>
 
                 </p>
             </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -134,8 +134,7 @@ and supports generic programming.</p>
                     (empty)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns an empty Vector
-</code></pre>
+                    <p>Returns an empty Vector</p>
 
                 </p>
             </div>
@@ -155,8 +154,7 @@ and supports generic programming.</p>
                     (head v)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns the first element of a Vector.
-</code></pre>
+                    <p>Returns the first element of a Vector.</p>
 
                 </p>
             </div>
@@ -215,8 +213,7 @@ and supports generic programming.</p>
                     (last v)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns the last element of a Vector.
-</code></pre>
+                    <p>Returns the last element of a Vector.</p>
 
                 </p>
             </div>
@@ -277,14 +274,11 @@ and supports generic programming.</p>
                     (nth v ix)
                 </pre>
                 <p class="doc">
-                    <pre><code>Retrieves the nth element of a Vector using a given `Index`.
-
-The given `Index` must have a `Size` equivalent to the `Vector`'s size in
-its first position (the bound position).
-
-If the `Index`'s Int value exceeds the length of the Vector, this
-function will return the last element of the Vector.
-</code></pre>
+                    <p>Retrieves the nth element of a Vector using a given <code>Index</code>.</p>
+<p>The given <code>Index</code> must have a <code>Size</code> equivalent to the <code>Vector</code>'s size in
+its first position (the bound position).</p>
+<p>If the <code>Index</code>'s Int value exceeds the length of the Vector, this
+function will return the last element of the Vector.</p>
 
                 </p>
             </div>
@@ -304,8 +298,7 @@ function will return the last element of the Vector.
                     (of values)
                 </pre>
                 <p class="doc">
-                    <pre><code>Creates a new Vector from the contents of an Array literal.
-</code></pre>
+                    <p>Creates a new Vector from the contents of an Array literal.</p>
 
                 </p>
             </div>
@@ -364,8 +357,7 @@ function will return the last element of the Vector.
                     (push x v)
                 </pre>
                 <p class="doc">
-                    <pre><code>Adds an element to the end of a Vector, returning a new Vector.
-</code></pre>
+                    <p>Adds an element to the end of a Vector, returning a new Vector.</p>
 
                 </p>
             </div>
@@ -424,8 +416,7 @@ function will return the last element of the Vector.
                     (tail v)
                 </pre>
                 <p class="doc">
-                    <pre><code>Returns all but the first element of a Vector as a new Vector.
-</code></pre>
+                    <p>Returns all but the first element of a Vector as a new Vector.</p>
 
                 </p>
             </div>
@@ -445,8 +436,7 @@ function will return the last element of the Vector.
                     (to-array v)
                 </pre>
                 <p class="doc">
-                    <pre><code>Converts a Vector to an Array.
-</code></pre>
+                    <p>Converts a Vector to an Array.</p>
 
                 </p>
             </div>
@@ -466,8 +456,7 @@ function will return the last element of the Vector.
                     (zip f v v1)
                 </pre>
                 <p class="doc">
-                    <pre><code>Combines two Vectors using a binary function `f`.
-</code></pre>
+                    <p>Combines two Vectors using a binary function <code>f</code>.</p>
 
                 </p>
             </div>

--- a/docs/index-type.html
+++ b/docs/index-type.html
@@ -135,10 +135,8 @@
                     (index-to-int ix)
                 </pre>
                 <p class="doc">
-                    <pre><code>Converts an index to a safe integer value, for sized functor element access.
-
-The integer value will always be lesser than the `Size` encoded in the `Index`.
-</code></pre>
+                    <p>Converts an index to a safe integer value, for sized functor element access.</p>
+<p>The integer value will always be lesser than the <code>Size</code> encoded in the <code>Index</code>.</p>
 
                 </p>
             </div>

--- a/impl/vector.carp
+++ b/impl/vector.carp
@@ -20,9 +20,9 @@
     (fn [i]
       (Vector.nth &v i)))
 
-   (doc map "
-     Maps a function `f` over all the elements of a Vector and returns a new
-     Vector containing the results.")
+   (doc map
+     "Maps a function `f` over all the elements of a Vector and returns a new "
+     "Vector containing the results.")
    (implements smap map)
    (sig map (Fn [(Ref (Fn [a] b)) (Ref (Vector (Size n) a))] (Vector (Size n) b)))
    (defn map [f v]

--- a/src/dimensional.carp
+++ b/src/dimensional.carp
@@ -7,28 +7,28 @@
 (definterface smap (Fn [(Ref (Fn [a] b)) (Ref (f s a))] (f s b)))
 
 (defmodule Dimensional
-  (doc tabulate "
-    Tabulate maps a `lookup` function (any function that takes an `Index` as an
-    argument) over the positions of a sized functor.
-
-    `(tabulate (lookup f))= (id f)`
-
-    To make this function useful, one often needs to use an overarching context
-    to ensure the resulting functor is sized appropriately. ")
+  (doc tabulate
+    "Tabulate maps a `lookup` function (any function that takes an `Index` as an "
+    "argument) over the positions of a sized functor."
+    ""
+    "`(tabulate (lookup f))= (id f)`"
+    ""
+    "To make this function useful, one often needs to use an overarching context "
+    "to ensure the resulting functor is sized appropriately.")
   (defn tabulate [f]
     (smap f &(positions)))
 
-  (doc transpose "
-    Transpose takes a sized functor whose inhabitants are sized functors and
-    effectively swaps their sizes; it is equivalent to matrix transposition.
-
-    For example, given a Vector of Size 3 of Vectors of Size 2
-
-    `(Vector [(Vector [1 2]) (Vector [3 4]) (Vector [5 6])])`
-
-    transpose will return a Vector of size 2 of Vectors of size 3:
-
-    `(Vector [(Vector [1 3 5]) (Vector [2 4 6])])`")
+(doc transpose
+  "Transpose takes a sized functor whose inhabitants are sized functors and "
+  "effectively swaps their sizes; it is equivalent to matrix transposition."
+  ""
+  "For example, given a Vector of Size 3 of Vectors of Size 2"
+  ""
+  "`(Vector [(Vector [1 2]) (Vector [3 4]) (Vector [5 6])])`"
+  ""
+  "transpose will return a Vector of size 2 of Vectors of size 3:"
+  ""
+  "`(Vector [(Vector [1 3 5]) (Vector [2 4 6])])`")
   (sig transpose (Fn [(Ref (f (Size n) (g (Size m) a)))] (g (Size m) (f (Size n) a))))
   (defn transpose [f]
     (tabulate &(fn [i] (smap &(fn [x] ((lookup x) i)) f))))

--- a/src/hompair.carp
+++ b/src/hompair.carp
@@ -2,100 +2,100 @@
 (load "src/index.carp")
 (load "Phantom.carp")
 
-(doc Hompair "
-  Hompairs are sized pairs of values of the *same* type.
-
-  Since all Hompairs are pairs of values, their size is fixed; they always have a Size of 2.
-
-  Hompairs implement the [dimensional interfaces](dimensional.html).")
+(doc Hompair
+  "Hompairs are sized pairs of values of the *same* type."
+  ""
+  "Since all Hompairs are pairs of values, their size is fixed; they always have a Size of 2."
+  ""
+  "Hompairs implement the [dimensional interfaces](dimensional.html).")
 (deftype (Hompair s a) [first a second a])
 (hidden Hompair.init)
 (private Hompair.init)
 
 (defmodule Hompair
- (doc of "
-    Constructs a new Hompair from values `x` and `y`.
-
-    ```
-    (Hompair.of 2 4)
-    => (Hompair 2 4)
-    ```")
+ (doc of
+    "Constructs a new Hompair from values `x` and `y`."
+    ""
+    "```"
+    "(Hompair.of 2 4)"
+    "=> (Hompair 2 4)"
+    "```")
   (sig of (Fn [a a] (Hompair (Size.size 2) a)))
   (defn of [x y]
     (Hompair.init x y))
 
-  (doc swap "
-    Swaps the position of each value in a Hompair.
-
-    ```
-    (swap &(Hompair.of 1 2))
-    => (Hompair 2 1)
-    ```")
+  (doc swap
+    "Swaps the position of each value in a Hompair."
+    ""
+    "```"
+    "(swap &(Hompair.of 1 2))"
+    "=> (Hompair 2 1)"
+    "```")
   (sig swap (Fn [(Ref (Hompair (Size.size 2) a))] (Hompair (Size.size 2) a)))
   (defn swap [pair]
     (let [a @(Hompair.first pair)
           b @(Hompair.second pair)]
       (Hompair.of b a)))
 
-  (doc nth "
-    Retrieves the nth value from a Hompair using the int value of `index`. 
-    If n is greater than or equal 1, returns the second member of the Hompair.
-
-    ```
-    (nth &(Hompair 1 2) (Index.init 0))
-    => 1
-    ```")
+  (doc nth
+    "Retrieves the nth value from a Hompair using the int value of `index`. "
+    "If n is greater than or equal 1, returns the second member of the Hompair."
+    ""
+    "```"
+    "(nth &(Hompair 1 2) (Index.init 0))"
+    "=> 1"
+    "```")
   (sig nth (Fn [(Ref (Hompair (Size.size 2) a)) (Index (Hompair (Size.size 2) Opaque) Int)] a))
   (defn nth [pair index]
     (if (= 0 (to-int &index))
         @(Hompair.first pair)
         @(Hompair.second pair)))
- 
-  (doc zero "
-    Returns a Hompair of the zero values of a given type.")
+
+  (doc zero
+    "Returns a Hompair of the zero values of a given type.")
   (sig zero (Fn [] (Hompair (Size.size 2) a)))
   (implements zero zero)
   (defn zero []
     (Hompair.of (zero) (zero)))
 
-  (doc replicate "
-    Creates a new Hompair with `x` as both of its members.
-
-    ```
-    (Hompair.replicate 1)
-    => (Hompair 1 1)
-    ```")
+  (doc replicate
+    "Creates a new Hompair with `x` as both of its members."
+    ""
+    "```"
+    "(Hompair.replicate 1)"
+    "=> (Hompair 1 1)"
+    "```")
   (sig replicate (Fn [a] (Hompair (Size.size 2) a)))
   (implements replicate replicate)
   (defn replicate [x]
     (Hompair.of x x))
 
-  (doc len "
-    Returns the length of a Hompair.
- 
-    ```
-    (len (Hompair.of 1 1))
-    => 2
-    ```")
+  (doc len
+    "Returns the length of a Hompair."
+    ""
+    "```"
+    "(len (Hompair.of 1 1))"
+    "=> 2"
+    "```")
   (sig len (Fn [(Ref (Hompair (Size.size 2) a))] Int))
   (implements len len)
-  (defn len [pair] 
+  (defn len [pair]
     2)
- 
-  (doc empty? "
-    Returns false. Hompairs may never be empty by definition.
-  
-    ```
-    (empty? &(Hompair.of 1 1))
-    => false
-    ```")
+
+  (doc empty?
+    "Returns false. Hompairs may never be empty by definition."
+    ""
+    "```"
+    "(empty? &(Hompair.of 1 1))"
+    "=> false"
+    "```")
   (sig empty? (Fn [(Ref (Hompair (Size.size 2) a))] Bool))
   (implements empty? empty?)
   (defn empty? [pair]
     false)
-  
+
   (implements = ref=)
   (defn ref= [pair other-pair]
-    (and (= @(Hompair.first pair) @(Hompair.first other-pair)) 
+    (and (= @(Hompair.first pair) @(Hompair.first other-pair))
          (= @(Hompair.second pair) @(Hompair.second other-pair))))
 )

--- a/src/index.carp
+++ b/src/index.carp
@@ -1,18 +1,18 @@
 (load "src/size.carp")
 (load "Phantom.carp")
 
-(doc Index "
-  The type of integer indicies.
-
-  This type can be used to define generic lookup functions over sized functors
-  (Functors with a phantom [Size](size.html) type argument.)")
+(doc Index
+  "The type of integer indicies."
+  ""
+  "This type can be used to define generic lookup functions over sized functors"
+  "(Functors with a phantom [Size](size.html) type argument.)")
 (deftype (Index (f (Size n) Opaque) Int) [at Int])
 
 (defmodule Index
-  (doc index-to-int "
-    Converts an index to a safe integer value, for sized functor element access.
-
-    The integer value will always be lesser than the `Size` encoded in the `Index`.")
+  (doc index-to-int
+    "Converts an index to a safe integer value, for sized functor element access."
+    ""
+    "The integer value will always be lesser than the `Size` encoded in the `Index`.")
   (implements to-int index-to-int)
   (sig index-to-int (Fn [(Ref (Index (f (Size m) Opaque) Int))] Int))
   (defn index-to-int [ix]

--- a/src/size.carp
+++ b/src/size.carp
@@ -1,19 +1,19 @@
 (load "Phantom.carp")
 
-(doc Zero "
-  The type of things with zero size.")
+(doc Zero
+  "The type of things with zero size.")
 (deftype Zero)
 
-(doc Size "
-  The type of things with some fixed size.
-
-  Sizes larger than [Zero](#zero) are represented by nested applications of
-  Size.
-
-  For example, things of size 2 are typed: `(Size (Size Zero))`
-
-  Functions that rely on information about the size or length of a structure
-  are implemented in terms of `Size` and `Zero`.")
+(doc Size
+  "The type of things with some fixed size."
+  ""
+  "Sizes larger than [Zero](#zero) are represented by nested applications of"
+  "Size."
+  ""
+  "For example, things of size 2 are typed: `(Size (Size Zero))`"
+  ""
+  "Functions that rely on information about the size or length of a structure"
+  "are implemented in terms of `Size` and `Zero`.")
 (deftype (Size s))
 
 (defmodule Size
@@ -23,11 +23,11 @@
         acc
         (Size.gen-size (- n 1) (cons-last acc '(Size)))))
 
-  (doc size "
-    Size types can be quite a pain to type out in full, as the rely on significant nesting.
-
-    The size macro generates an appropriate Size based on an integer value, and
-    may be used to generate a size type in functions signatures and macros.")
+  (doc size
+    "Size types can be quite a pain to type out in full, as the rely on significant nesting."
+    ""
+    "The size macro generates an appropriate Size based on an integer value, and"
+    "may be used to generate a size type in functions signatures and macros.")
   (defmacro size [n]
     (Size.gen-size (- n 1) '(Size Zero)))
 )

--- a/src/vector.carp
+++ b/src/vector.carp
@@ -2,10 +2,10 @@
 (load "src/index.carp")
 (load "Phantom.carp")
 
-(doc Vector "
-  Vector is an array-like type that supports length/bounds checking at
-  type-level. It also implements the [dimensional interfaces](dimensional.html)
-  and supports generic programming.")
+(doc Vector
+  "Vector is an array-like type that supports length/bounds checking at"
+  "type-level. It also implements the [dimensional interfaces](dimensional.html)"
+  "and supports generic programming.")
 (deftype (Vector s a) [elements (Array a)])
 (hidden Vector.elements)
 (private Vector.elements)
@@ -22,33 +22,33 @@
 ;(definterface empty? (Fn [(Ref (Vector n a))] Bool))
 
 (defmodule Vector
-  (doc push "
-    Adds an element to the end of a Vector, returning a new Vector.")
+  (doc push
+    "Adds an element to the end of a Vector, returning a new Vector.")
   (sig push (Fn [a (Ref (Vector n a))] (Vector (Size n) a)))
   (defn push [x v]
     (Vector.init (Array.push-back @(Vector.elements v) x)))
 
-  (doc tail "
-    Returns all but the first element of a Vector as a new Vector.")
+  (doc tail
+    "Returns all but the first element of a Vector as a new Vector.")
   (sig tail (Fn [(Ref (Vector (Size n) a))] (Vector n a)))
   (defn tail [v]
     (Vector.init (Array.suffix (Vector.elements v) 1)))
 
-  (doc empty "
-    Returns an empty Vector")
+  (doc empty
+    "Returns an empty Vector")
   (implements zero empty)
   (sig empty (Fn [] (Vector Zero a)))
   (defn empty []
     (Vector.init []))
 
-  (doc to-array "
-    Converts a Vector to an Array.")
+  (doc to-array
+    "Converts a Vector to an Array.")
   (sig to-array (Fn [(Ref (Vector n a))] (Array a)))
   (defn to-array [v]
     @(Vector.elements v))
 
-  (doc zip "
-    Combines two Vectors using a binary function `f`.")
+  (doc zip
+    "Combines two Vectors using a binary function `f`.")
   (sig zip (Fn [(Ref (Fn [a b] c)) (Ref (Vector n a)) (Ref (Vector n b))] (Vector n c)))
   (defn zip [f v v1]
     (let [copy-then-apply (fn [a b] (~f @a @b))
@@ -56,26 +56,26 @@
           arr1 (Vector.elements v1)]
       (Vector.init (Array.zip &copy-then-apply arr arr1))))
 
-  (doc nth "
-    Retrieves the nth element of a Vector using a given `Index`.
-
-    The given `Index` must have a `Size` equivalent to the `Vector`'s size in
-    its first position (the bound position).
-
-    If the `Index`'s Int value exceeds the length of the Vector, this
-    function will return the last element of the Vector.")
+  (doc nth
+    "Retrieves the nth element of a Vector using a given `Index`."
+    ""
+    "The given `Index` must have a `Size` equivalent to the `Vector`'s size in"
+    "its first position (the bound position)."
+    ""
+    "If the `Index`'s Int value exceeds the length of the Vector, this"
+    "function will return the last element of the Vector.")
   (sig nth (Fn [(Ref (Vector (Size n) a)) (Index (Vector (Size n) Opaque) Int)] a))
   (defn nth [v ix]
     @(Array.unsafe-nth (Vector.elements v) (to-int &ix)))
 
-  (doc last "
-    Returns the last element of a Vector.")
+  (doc last
+    "Returns the last element of a Vector.")
   (sig last (Fn [(Ref (Vector (Size n) a))] a))
   (defn last [v]
     @(Array.unsafe-nth (Vector.elements v) (to-int (the (Phantom n) (Phantom.init)))))
 
-  (doc head "
-    Returns the first element of a Vector.")
+  (doc head
+    "Returns the first element of a Vector.")
   (sig head (Fn [(Ref (Vector (Size n) a))] a))
   (defn head [v]
     @(Array.unsafe-nth (Vector.elements v) (to-int (the (Phantom Zero) (Phantom.init)))))
@@ -86,8 +86,8 @@
         acc
         (Vector.gen-vec (cdr vs) (cons-last (list 'Vector.push (car vs)) (cons-last '(ref) acc)))))
 
-  (doc of "
-    Creates a new Vector from the contents of an Array literal.")
+  (doc of
+    "Creates a new Vector from the contents of an Array literal.")
   (defmacro of [values]
     (if (= 0 (length values))
         (list 'Vector.empty)


### PR DESCRIPTION
This PR makes use of new-style docs to avoid emitting code block where we don’t want to.

Cheers