### PR TITLE
Remove empty? interface

### DIFF
--- a/src/size.carp
+++ b/src/size.carp
@@ -47,4 +47,3 @@
 ;; Generic interfaces for sized types
 (definterface len (Fn [(Ref (f n a))] Int))
 (definterface replicate (Fn [a] (f n a)))
-(definterface empty? (Fn [(Ref (f n a))] Bool))


### PR DESCRIPTION
empty? is now defined as an interface in Carp's core library, so we no
longer need the definition provided here.